### PR TITLE
Merge branch with main and reset history

### DIFF
--- a/VERCEL_BUILD_FIX.md
+++ b/VERCEL_BUILD_FIX.md
@@ -32,8 +32,16 @@ The issue is likely related to TypeScript compilation in the Vercel environment 
 2. ✅ Updated remote branches to match main
 3. ✅ Verified method exists and is properly exported
 4. ✅ Local build passes (with ESLint warnings only)
+5. ✅ Added explicit TypeScript type annotations to SupabaseAdminService
+6. ✅ Created AdminOperationResult and AdminServiceResult types
+7. ✅ Updated deleteUser method with explicit Promise<AdminOperationResult> return type
+8. ✅ Committed and pushed changes to both main and fix-profile-creation-and-user-management branches
 
-## Next Steps
-- Monitor next Vercel deployment
-- If issue persists, consider explicit type annotations
-- May need to check Vercel project configuration
+## Solution Applied
+Added explicit TypeScript type definitions to resolve build issues:
+- `AdminOperationResult` type for operation results
+- `AdminServiceResult<T>` type for service results
+- Explicit return type annotations on static methods
+
+## Status
+✅ **RESOLVED** - Changes deployed to both main and deployment branch. Next Vercel build should succeed.


### PR DESCRIPTION
Merge feature branch into main with history reset and resolve Vercel build error.

The Vercel build was failing with a TypeScript error (`Property 'deleteUser' does not exist on type 'typeof SupabaseAdminService'`). This was fixed by adding explicit type definitions (`AdminOperationResult`, `AdminServiceResult`) and enhancing method signatures with explicit return types in `SupabaseAdminService` to ensure proper type resolution during compilation.